### PR TITLE
[Fix] Bump flask version to fix import error

### DIFF
--- a/flask_helloworld/requirements.txt
+++ b/flask_helloworld/requirements.txt
@@ -1,2 +1,2 @@
-flask==1.0.2
+flask==2.0.3
 itsdangerous==2.0.1


### PR DESCRIPTION
This PR fixes the following error observed recently

```python
Traceback (most recent call last):
  File "/app/app.py", line 1, in <module>
    from flask import Flask
  File "/usr/local/lib/python3.7/site-packages/flask/__init__.py", line 19, in <module>
    from jinja2 import Markup, escape
ImportError: cannot import name 'Markup' from 'jinja2' (/usr/local/lib/python3.7/site-packages/jinja2/__init__.py)

```